### PR TITLE
Username typo in cluster-api-provider-openstack

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
@@ -1,6 +1,6 @@
 approvers:
 - flaper87
 - Lion-Wei
-- chaoscaffe
+- chaosaffe
 - m1093782566
 - dims


### PR DESCRIPTION
Minor typo in usernames when cluster-api-provider-openstack was added to test-infra
/chaoscaffe/chaosaffe/

xref: #9750

/area test-grid
/area config